### PR TITLE
Fixed kwarg.pop issue on serial jobs by using kwargs.get instead

### DIFF
--- a/pcntoolkit/normative.py
+++ b/pcntoolkit/normative.py
@@ -713,7 +713,7 @@ def predict(covfile, respfile, maskfile=None, **kwargs):
         if (alg!='hbr' or nm.configs['transferred']==False):
             yhat, s2 = nm.predict(Xz, **kwargs)
         else:
-            tsbefile = kwargs.pop('tsbefile') 
+            tsbefile = kwargs.get('tsbefile') 
             batch_effects_test = fileio.load(tsbefile)
             yhat, s2 = nm.predict_on_new_sites(Xz, batch_effects_test)
         


### PR DESCRIPTION
Fixes an issue on running predict in serial jobs with > 1 features if  **not** (alg!='hbr' or nm.configs['transferred']==False), where kwargs,pop would remove the key and its value, causing an error for the next iteration of the 'for' loop.
The other kwargs.pop were left, as they are not inside for loops.