### PR TITLE
Proposed adjustments after testing in Meganorm project

### DIFF
--- a/pcntoolkit/dataio/norm_data.py
+++ b/pcntoolkit/dataio/norm_data.py
@@ -269,6 +269,7 @@ class NormData(xr.Dataset):
         batch_effects: List[str] | None = None,
         response_vars: List[str | LiteralString] | None = None,
         subject_ids: List[str] | None = None,
+        remove_Nan: bool = False, 
         attrs: Mapping[str, Any] | None = None,
     ) -> NormData:
         """
@@ -288,12 +289,26 @@ class NormData(xr.Dataset):
             The list of column names to be used as response variables in the dataset.
         attrs : Mapping[str, Any] | None, optional
             Additional attributes for the dataset, by default None.
+        remove_Nan: bool 
+            Wheter or not to remove NAN values from the dataframe before creationg of the class object. By default False 
 
         Returns
         -------
         NormData
             An instance of NormData.
         """
+
+        if remove_Nan:
+            cols_to_check = []
+            if covariates:
+                cols_to_check += covariates
+            if response_vars:
+                cols_to_check += response_vars
+            if batch_effects:
+                cols_to_check += batch_effects
+            dataframe = dataframe.dropna(subset=cols_to_check)
+        else:
+            print("Warning: remove_NAN is set to False. Missing (NaN) values may cause errors during model creation or training.")
 
         data_vars = {}
         coords = {}

--- a/pcntoolkit/normative_model.py
+++ b/pcntoolkit/normative_model.py
@@ -762,6 +762,14 @@ class NormativeModel:
             with open(os.path.join(regmodel_path, "regression_model.json"), "w", encoding="utf-8") as f:
                 json.dump(reg_model_dict, f, indent=4)
 
+    def ensure_save_dirs(self) -> None:
+        """
+        Ensures that the save directories for results and plots are created when they are not there yet
+        """
+        os.makedirs(os.path.join(self.save_dir, "results"), exist_ok=True)
+        if self.saveplots:
+            os.makedirs(os.path.join(self.save_dir, "plots"), exist_ok=True)
+
     def to_dict(self):
         my_dict = {
             "save_dir": self.save_dir,
@@ -893,6 +901,7 @@ class NormativeModel:
 
 
     def save_zscores(self, data: NormData) -> None:
+        self.ensure_save_dirs()
         zdf = data.Z.to_dataframe().unstack(level="response_vars")
         zdf.columns = zdf.columns.droplevel(0)
         zdf.index = zdf.index.astype(str)
@@ -922,6 +931,7 @@ class NormativeModel:
 
 
     def save_centiles(self, data: NormData) -> None:
+        self.ensure_save_dirs()
         centiles = data.centiles.to_dataframe().unstack(level="response_vars")
         centiles.columns = centiles.columns.droplevel(0)
         centiles.index = centiles.index.set_levels(centiles.index.levels[1].astype(str), level=1)
@@ -955,6 +965,7 @@ class NormativeModel:
             )
 
     def save_logp(self, data: NormData) -> None:
+        self.ensure_save_dirs()
         logp = data.logp.to_dataframe().unstack(level="response_vars")
         logp.columns = logp.columns.droplevel(0)
         logp.index = logp.index.astype(str)
@@ -981,6 +992,7 @@ class NormativeModel:
 
 
     def save_statistics(self, data: NormData) -> None:
+        self.ensure_save_dirs()
         mdf = data.statistics.to_dataframe().unstack(level="response_vars")
         mdf.columns = mdf.columns.droplevel(0)
         res_path = os.path.join(self.save_dir, "results", f"statistics_{data.name}.csv")

--- a/pcntoolkit/normative_model.py
+++ b/pcntoolkit/normative_model.py
@@ -152,6 +152,8 @@ class NormativeModel:
         self.is_fitted = True
         self.postprocess(data)
         self.predict(data) # Make sure everything is evaluated and saved
+        if self.savemodel: # Make sure model is saved 
+            self.save()
 
     def predict(self, data: NormData) -> NormData:
         """Computes Z-scores and centiles for each response variable using fitted regression models."""
@@ -437,6 +439,8 @@ class NormativeModel:
         """
         self.fit(fit_data)
         self.predict(predict_data)
+        if self.savemodel: #Make sure model is saved 
+            self.save()
         return predict_data
 
     def extract_data(self, data: NormData) -> Tuple[xr.DataArray, xr.DataArray, dict[str, dict[str, int]], xr.DataArray]:

--- a/pcntoolkit/normative_model.py
+++ b/pcntoolkit/normative_model.py
@@ -814,6 +814,9 @@ class NormativeModel:
         if hasattr(self, "batch_effect_covariate_ranges"):
             my_dict["batch_effect_covariate_ranges"] = copy.deepcopy(self.batch_effect_covariate_ranges)
 
+        if hasattr(self, "covariate_ranges"):
+            my_dict["covariate_ranges"] = copy.deepcopy(self.covariate_ranges)
+
         return my_dict
 
     @classmethod
@@ -900,6 +903,10 @@ class NormativeModel:
 
         if "covariates" in metadata:
             self.covariates = metadata["covariates"]
+        
+        if "covariate_ranges" in metadata:
+            self.covariate_ranges = metadata["covariate_ranges"]
+
 
         self.is_fitted = metadata["is_fitted"]
 

--- a/pcntoolkit/normative_model.py
+++ b/pcntoolkit/normative_model.py
@@ -140,6 +140,7 @@ class NormativeModel:
             - Y: (n_samples, n_response_vars)
 
         """
+        self.ensure_save_dirs() 
         self.register_data_info(data)
         self.preprocess(data)
         Output.print(Messages.FITTING_MODELS, n_models=len(self.response_vars))
@@ -764,9 +765,10 @@ class NormativeModel:
 
     def ensure_save_dirs(self) -> None:
         """
-        Ensures that the save directories for results and plots are created when they are not there yet
+        Ensures that the save directories for results and plots are created when they are not there yet (otherwise resulted in an error)
         """
         os.makedirs(os.path.join(self.save_dir, "results"), exist_ok=True)
+        os.makedirs(os.path.join(self.save_dir, "model"), exist_ok=True)
         if self.saveplots:
             os.makedirs(os.path.join(self.save_dir, "plots"), exist_ok=True)
 
@@ -901,7 +903,6 @@ class NormativeModel:
 
 
     def save_zscores(self, data: NormData) -> None:
-        self.ensure_save_dirs()
         zdf = data.Z.to_dataframe().unstack(level="response_vars")
         zdf.columns = zdf.columns.droplevel(0)
         zdf.index = zdf.index.astype(str)
@@ -931,7 +932,6 @@ class NormativeModel:
 
 
     def save_centiles(self, data: NormData) -> None:
-        self.ensure_save_dirs()
         centiles = data.centiles.to_dataframe().unstack(level="response_vars")
         centiles.columns = centiles.columns.droplevel(0)
         centiles.index = centiles.index.set_levels(centiles.index.levels[1].astype(str), level=1)
@@ -965,7 +965,6 @@ class NormativeModel:
             )
 
     def save_logp(self, data: NormData) -> None:
-        self.ensure_save_dirs()
         logp = data.logp.to_dataframe().unstack(level="response_vars")
         logp.columns = logp.columns.droplevel(0)
         logp.index = logp.index.astype(str)
@@ -992,7 +991,6 @@ class NormativeModel:
 
 
     def save_statistics(self, data: NormData) -> None:
-        self.ensure_save_dirs()
         mdf = data.statistics.to_dataframe().unstack(level="response_vars")
         mdf.columns = mdf.columns.droplevel(0)
         res_path = os.path.join(self.save_dir, "results", f"statistics_{data.name}.csv")

--- a/pcntoolkit/normative_model.py
+++ b/pcntoolkit/normative_model.py
@@ -156,6 +156,7 @@ class NormativeModel:
             self.save()
 
     def predict(self, data: NormData) -> NormData:
+        self.ensure_save_dirs() 
         """Computes Z-scores and centiles for each response variable using fitted regression models."""
         self.compute_zscores(data)
         self.compute_centiles(data)
@@ -187,6 +188,7 @@ class NormativeModel:
         covariate_range_per_batch_effect : bool, optional
             If True, the covariate range is different for each batch effect.
         """
+        self.ensure_save_dirs() 
         assert self.is_fitted
         if data:
             self.check_compatibility(data)
@@ -246,6 +248,7 @@ class NormativeModel:
         reference_batch_effect : dict[str, str]
             Reference batch effect.
         """
+        self.ensure_save_dirs() 
         self.preprocess(data)
         _, be, _, _ = self.extract_data(data)
         ref_be_array = be.astype(str)
@@ -464,6 +467,7 @@ class NormativeModel:
         """
         Transfers the model to a new dataset.
         """
+        self.ensure_save_dirs() 
         new_model = NormativeModel(
             copy.deepcopy(self.template_regression_model),
             savemodel=True,
@@ -513,6 +517,7 @@ class NormativeModel:
         """
         Extends the model to a new dataset.
         """
+        self.ensure_save_dirs() 
         synth = self.synthesize(n_samples=n_synth_samples, covariate_range_per_batch_effect=True)
         self.postprocess(synth)
         self.postprocess(data)

--- a/pcntoolkit/util/evaluator.py
+++ b/pcntoolkit/util/evaluator.py
@@ -326,7 +326,7 @@ class Evaluator:
         yhat = data["Yhat"].values
 
         mse = np.mean((y - yhat) ** 2)
-        variance = np.var((y - np.mean(y)) ** 2)
+        variance = np.var(y)
         smse = float(mse / variance if variance != 0 else 0)
 
         return smse


### PR DESCRIPTION
I am trying to use the refactored version for the Meganorm project. I encountered some issues and tried to fix them. 

* Added code to handle situations where the required directories (`results/` and `plots/`) do not exist yet.
When I ran it initially, saving evaluation metrics resulted in an error because the needed directories did not exist and where not automatically created (like they were before I think). To prevent this error, I added code to ensure these directories are created if missing, which allowed the evaluation metrics to be saved.

* Models where not saved when savemodel was set to True, I added code that explicitly saves the models after fitting 

* In the original version of the PCNtoolkit, Nan values were handled automatically. This is not the case anymore and it results in an error. After discussion with Mosi I added an option to delete rows in the data where covariates, response variables or batch effects have Nan values. 

* Covariate_ranges where not saved to the normative_model.json but are necessary for (eg.) the plot_centile function. Added code that saves them to_dict


(My apologies for the messy commits, I adjust every time I encounter an error while testing) 

